### PR TITLE
TOPページに最新のトーク5件表示＆talksテーブルにposts_numberカラム追加,実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,28 +3,31 @@
 namespace App\Http\Controllers;
 
 use App\Post;
-// use Illuminate\Http\Request;
+use App\Talk;
 use App\Http\Requests\PostRequest;
+// use Illuminate\Http\Request;
 
 class PostController extends Controller
 {
     
-    // ユーザーから新規投稿があった場合、入力した投稿内容と属するトークのIDをDBに保存し、トーク画面へリダイレクトする処理
-    public function store(PostRequest $request, Post $post)
+    // ユーザーから新規投稿があった場合、入力した投稿内容と属するトークのIDをDBに保存＆属するtalkの投稿数に＋1し、トーク画面へリダイレクトする処理
+    public function store(PostRequest $request, Post $post, Talk $talk)
     {
-        // talk_idとbodyを取得
+        // ユーザーからの入力(talk_idとbody)を取得し、投稿データを上書き
         $input = $request['post'];
         $post->fill($input)->save();
+        // ユーザーが投稿しているトークを特定
+        $belong_to_talk = Talk::find($post->talk_id);
+        // 属するトークの直前までの投稿数を取得
+        $current_posts_number = $belong_to_talk['posts_number'];
+        // 投稿数に＋1
+        $current_posts_number += 1;
+        // ＋1した投稿数を、属するトークのposts_number(投稿数)カラムに代入(更新)
+        $belong_to_talk->posts_number = $current_posts_number;
+        // 保存
+        $belong_to_talk->save();
+        // トーク画面にリダイレクト
         return redirect('/talks_latest/'.$post->talk_id);
     }
 
-    // 今後使用する可能性があるため、一応コメントアウトにて残しておく。
-    // public function update(Request $request, Post $post)
-    // {
-    //     $input_post = $request['post'];
-    //     // $input_post += ['talk_id' => $request['post']->talk()->id];    //この行を追加
-    //     $post->fill($input_post)->save();
-    //     return redirect('/talks_latest/'.$post->talk_id);
-    // }
-    
 }

--- a/app/Http/Controllers/TalkController.php
+++ b/app/Http/Controllers/TalkController.php
@@ -7,6 +7,12 @@ use Illuminate\Http\Request;
 
 class TalkController extends Controller
 {
+    
+    // TOPページにリクエストが来た際、最新のトークを5件表示する処理
+    public function index_latest_top(Talk $talk)
+    {
+        return view('index')->with(['talks_latest' => $talk->getTalksByLimit_latest()]);
+    }
 
     // 最新のトーク一覧画面にリクエストが来た場合の処理
     public function index_latest(Talk $talk)

--- a/app/Talk.php
+++ b/app/Talk.php
@@ -7,6 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 class Talk extends Model
 {
 
+    // TOPページにリクエストが来た際、最新のトークを5件表示する処理
+    public function getTalksByLimit_latest(int $limit_count = 5)
+    {
+        return $this->orderBy('created_at', 'DESC')->limit($limit_count)->get();
+    }
+
     // 最新のトークの一覧ページを表示するための処理
     public function getPaginateByLimit_latest(int $limit_count = 10)
     {
@@ -32,5 +38,6 @@ class Talk extends Model
         return $this::with('posts')->find(Talk::id())->posts()->orderBy('created_at', 'ASC')->paginate($limit_count);;
     }
     
+
 
 }

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -13,11 +13,24 @@
         <div class="container">
             <!--画面左側-->
             <div class="wrapper-left">
+                <!--人気のトーク-->
+                <div class="talks-popular">
+                    <h2>人気のトーク</h2>
+                    <div class="talk_popular_top">
+                        <p>・〇〇〇〇</p>
+                        <p>・〇〇〇〇</p>
+                    </div>
+                    <p><a href="/talks_popular">一覧へ</a></p>
+                </div>
                 <!--最新のトーク-->
                 <div class="talks-latest">
                     <h2>最新のトーク</h2>
-                    <p>・～～～</p>
-                    <p>・～～～</p>
+                    @foreach($talks_latest as $talk_latest)
+                    <div class="talk_latest_top">
+                        <h2 class="talk_latest_top--title"><a href="talks_latest/{{ $talk_latest->id }}">{{ $talk_latest->title }}</a></h2>
+                        <p class="talk_latest_top--created_at">{{ $talk_latest->created_at }}</p>
+                    </div>
+                    @endforeach
                     <p><a href="/talks_latest">一覧へ</a></p>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,9 @@ Route::get('/', function () {
     return view('index');
 });
 
+// TOPページにリクエストが来た際、最新のトークを5件表示するためのルーティング
+Route::get('/', 'TalkController@index_latest_top');
+
 // 最新のトーク一覧画面「/talks_latest」にリクエストが来た場合
 Route::get('/talks_latest', 'TalkController@index_latest');
 


### PR DESCRIPTION
・TOPページに最新のトークを5件表示する繰り返し処理を実装しました。
・talksテーブルに、そのトークに存在する投稿数を管理する「posts_number」カラムを追加し、ユーザーが投稿を作成＆送信するたびに、posts_numberカラムに＋1される処理を実装しました。