### PR TITLE
「人気のトーク」の実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,13 +2,14 @@
 
 namespace App\Http\Controllers;
 
-use App\Post;
 use App\Talk;
+use App\Post;
 use App\Http\Requests\PostRequest;
 // use Illuminate\Http\Request;
 
 class PostController extends Controller
 {
+
     
     // ユーザーから新規投稿があった場合、入力した投稿内容と属するトークのIDをDBに保存＆属するtalkの投稿数に＋1し、トーク画面へリダイレクトする処理
     public function store(PostRequest $request, Post $post, Talk $talk)
@@ -27,7 +28,8 @@ class PostController extends Controller
         // 保存
         $belong_to_talk->save();
         // トーク画面にリダイレクト
-        return redirect('/talks_latest/'.$post->talk_id);
+        return redirect('/talks/'.$post->talk_id);
     }
+
 
 }

--- a/app/Http/Controllers/TalkController.php
+++ b/app/Http/Controllers/TalkController.php
@@ -4,26 +4,41 @@ namespace App\Http\Controllers;
 
 use App\Talk;
 use Illuminate\Http\Request;
+use Carbon\Carbon;
 
 class TalkController extends Controller
 {
     
-    // TOPページにリクエストが来た際、最新のトークを5件表示する処理
-    public function index_latest_top(Talk $talk)
+    
+    // TOPページにリクエストが来た際、人気と最新のトークを5件表示する処理
+    public function top(Talk $talk)
     {
-        return view('index')->with(['talks_latest' => $talk->getTalksByLimit_latest()]);
+        return view('index')->with([
+            'talks_popular' => $talk->getTalksByLimit_popular(),
+            'talks_latest' => $talk->getTalksByLimit_latest()
+        ]);
     }
 
+
+    // 人気のトーク一覧画面にリクエストが来た場合の処理
+    public function index_popular(Talk $talk)
+    {
+        return view('talks_popular/index')->with(['talks' => $talk->getPaginateByLimit_popular()]);
+    }
+    
+    
     // 最新のトーク一覧画面にリクエストが来た場合の処理
     public function index_latest(Talk $talk)
     {
         return view('talks_latest/index')->with(['talks' => $talk->getPaginateByLimit_latest()]);
     }
     
-    // 最新のトーク一覧画面から、各トークの詳細画面（トークページ）にリクエストが来た場合の処理
-    public function show_latest(Talk $talk)
+    
+    // 人気と最新のトーク一覧画面から、各トークの詳細画面（トークページ）にリクエストが来た場合の処理
+    public function show(Talk $talk)
     {
-        return view('talks_latest/show')->with(['own_posts' => $talk->getOwnPostsByLimit(), 'talk' => $talk]);
+        return view('show')->with(['own_posts' => $talk->getOwnPostsByLimit(), 'talk' => $talk]);
     }
+
 
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -6,13 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    
+
     protected $fillable = [
         'body',
         'user_id',
         'talk_id'
     ];
-    
+
     //Talkに対するリレーション
     //「1対多」の関係なので単数系に
     public function talk()

--- a/app/Talk.php
+++ b/app/Talk.php
@@ -3,9 +3,19 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Carbon\Carbon; //test
 
 class Talk extends Model
 {
+
+
+    // TOPページにリクエストが来た際、人気のトークを5件表示する処理
+    public function getTalksByLimit_popular(int $limit_count = 5)
+    {
+        $sevendays = Carbon::today()->subDay(7);
+        return $talks_popular = Talk::whereDate('created_at', '>=', $sevendays)->orderBy('posts_number', 'DESC')->limit($limit_count)->get();
+    }
+
 
     // TOPページにリクエストが来た際、最新のトークを5件表示する処理
     public function getTalksByLimit_latest(int $limit_count = 5)
@@ -13,31 +23,42 @@ class Talk extends Model
         return $this->orderBy('created_at', 'DESC')->limit($limit_count)->get();
     }
 
+
+    // 人気のトークの一覧ページを表示するための処理
+    public function getPaginateByLimit_popular(int $limit_count = 10)
+    {
+        $sevendays = Carbon::today()->subDay(7);
+        return $talks_popular = Talk::whereDate('created_at', '>=', $sevendays)->orderBy('posts_number', 'DESC')->paginate($limit_count);
+    }
+
+
     // 最新のトークの一覧ページを表示するための処理
     public function getPaginateByLimit_latest(int $limit_count = 10)
     {
         return $this->orderBy('created_at', 'DESC')->paginate($limit_count);
     }
-    
+
+
     //Postに対するリレーション
     //「1対多」の関係なので'posts'と複数形に
     public function posts()
     {
         return $this->hasMany('App\Post');  
     }
-    
+
+
     // トークのIDを取得する処理
     public function id()
     {
         return $this->id;
     }
-    
+
+
     // そのトークに属する投稿を、作成日時の昇順で500件まで取得する処理
     public function getOwnPostsByLimit(int $limit_count = 500)
     {
         return $this::with('posts')->find(Talk::id())->posts()->orderBy('created_at', 'ASC')->paginate($limit_count);;
     }
-    
 
 
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "php": "^7.2.5|^8.0",
         "fideloper/proxy": "^4.4",
         "laravel/framework": "^6.20.26",
-        "laravel/tinker": "^2.5"
+        "laravel/tinker": "^2.5",
+        "nesbot/carbon": "^2.54"
     },
     "require-dev": {
         "facade/ignition": "^1.16.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e4a9dd2476552506dba12be3b05aeec",
+    "content-hash": "a3f5e415d5d85eab41e5272531d7650d",
     "packages": [
         {
             "name": "doctrine/inflector",

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -10,25 +10,28 @@
         <!--<link href="{{secure_asset('/assets/〇〇')}}" rel="stylesheet">-->
     </head>
     <body>
+        <!--内容-->
         <div class="container">
             <!--画面左側-->
             <div class="wrapper-left">
                 <!--人気のトーク-->
-                <div class="talks-popular">
+                <div class="top_talks--popular">
                     <h2>人気のトーク</h2>
-                    <div class="talk_popular_top">
-                        <p>・〇〇〇〇</p>
-                        <p>・〇〇〇〇</p>
+                    @foreach($talks_popular as $talk_popular)
+                    <div class="talk_popular">
+                        <h2 class="talk_popular--title"><a href="talks/{{ $talk_popular->id }}">{{ $talk_popular->title }}</a></h2>
+                        <p class="talk_popular--created_at">{{ $talk_popular->created_at }}</p>
                     </div>
+                    @endforeach
                     <p><a href="/talks_popular">一覧へ</a></p>
                 </div>
                 <!--最新のトーク-->
-                <div class="talks-latest">
+                <div class="top_talks--latest">
                     <h2>最新のトーク</h2>
                     @foreach($talks_latest as $talk_latest)
-                    <div class="talk_latest_top">
-                        <h2 class="talk_latest_top--title"><a href="talks_latest/{{ $talk_latest->id }}">{{ $talk_latest->title }}</a></h2>
-                        <p class="talk_latest_top--created_at">{{ $talk_latest->created_at }}</p>
+                    <div class="talk_latest">
+                        <h2 class="talk_latest--title"><a href="talks/{{ $talk_latest->id }}">{{ $talk_latest->title }}</a></h2>
+                        <p class="talk_latest--created_at">{{ $talk_latest->created_at }}</p>
                     </div>
                     @endforeach
                     <p><a href="/talks_latest">一覧へ</a></p>

--- a/resources/views/show.blade.php
+++ b/resources/views/show.blade.php
@@ -1,4 +1,4 @@
-<!--トークの詳細画面（トーク画面）-->
+<!--各トークの詳細画面（トーク画面）-->
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
@@ -24,10 +24,13 @@
                 <div class="create_post">
                     <input type="hidden" name="post[talk_id]" value="{{ $talk->id }}" />
                     <textarea name="post[body]" placeholder="投稿を作成する（最大100文字）">{{ old('post.body') }}</textarea>
-                    <p class="body--error" style="color:red">{{ $errors->first('post.body') }}</p>
+                    <p class="body_error" style="color:red">{{ $errors->first('post.body') }}</p>
                 </div>
                 <input type="submit" value="送信"/>
             </form>
+            <!--一覧画面へのリダイレクト-->
+            <p><a href="/talks_popular">「人気のトーク」一覧へ</a></p>
+            <p><a href="/talks_latest">「最新のトーク」一覧へ</a></p>
         </div>
     </body>
 </html>

--- a/resources/views/talks_popular/index.blade.php
+++ b/resources/views/talks_popular/index.blade.php
@@ -1,4 +1,4 @@
-<!--最新のトークの一覧ページ-->
+<!--人気のトークの一覧ページ-->
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
@@ -11,12 +11,13 @@
     </head>
     <body>
         <div class="container">
-            <!-- 最新のトーク一覧 -->
-            <h1>最新のトーク一覧</h1>
+            <!-- 人気のトーク一覧 -->
+            <h1>人気のトーク一覧</h1>
             <div class="talks">
                 @foreach($talks as $talk)
                     <div class="talk">
                         <h2 class="talk--title"><a href="talks/{{ $talk->id }}">{{ $talk->title }}</a></h2>
+                        <p class="talk--posts_number">投稿数：{{ $talk->posts_number }}</p>
                         <p class="talk--created_at">{{ $talk->created_at }}</p>
                     </div>
                 @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,19 +12,17 @@
 */
 
 
-// TOPページ「/」にリクエストが来たとき、TOPページのviewファイル（index.blade.php）を返す。
-Route::get('/', function () {
-    return view('index');
-});
+// TOPページにリクエストが来た際、人気と最新のトークを5件表示する処理
+Route::get('/', 'TalkController@top');
 
-// TOPページにリクエストが来た際、最新のトークを5件表示するためのルーティング
-Route::get('/', 'TalkController@index_latest_top');
+// 人気のトーク一覧画面「/talks_popular」にリクエストが来た場合
+Route::get('/talks_popular', 'TalkController@index_popular');
 
 // 最新のトーク一覧画面「/talks_latest」にリクエストが来た場合
 Route::get('/talks_latest', 'TalkController@index_latest');
 
-// 最新のトーク一覧画面から、各トークの詳細画面（各トークページ）にリクエストが来た場合
-Route::get('talks_latest/{talk}', 'TalkController@show_latest');
+// 人気と最新のトーク一覧画面から、各トークの詳細画面（各トークページ）にリクエストが来た場合
+Route::get('talks/{talk}', 'TalkController@show');
 
 // ユーザーが新規投稿を作成
 Route::post("/posts", 'PostController@store');


### PR DESCRIPTION
・「人気のトーク」一覧画面の実装
・「人気のトーク」の詳細画面の実装（「最新のトーク」と同様の詳細画面のため、ルーティングのみ設定）
・TOPページにて、7日以内に作成された投稿のうち、投稿数の多い5件のトークを表示する処理の実装